### PR TITLE
Fix parsing of GetPositionInfo creator

### DIFF
--- a/src/xml.rs
+++ b/src/xml.rs
@@ -128,8 +128,9 @@ pub(crate) fn parse_current_track_xml(xml: String) -> Result<CurrentTrack, XMLEr
         .text()
         .map(str::to_string);
 
-    let artist = get_tag_by_name(&parsed_xml, "creator")?
-        .text()
+    let artist = get_tag_by_name(&parsed_xml, "creator")
+        .ok()
+        .and_then(|node| node.text())
         .map(str::to_string);
 
     let position = get_text(get_tag_by_name(&parsed_xml, "RelTime")?)?;


### PR DESCRIPTION
`creator` is not always part of the response, but the parsing code assumed there is always such a tag in the response but that it can be empty. This fixes parse errors when playing things like http radio streams